### PR TITLE
fix tablePrefix prepend in addGlobalSearch

### DIFF
--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -1230,10 +1230,10 @@ class LivewireDatatable extends Component
                             foreach ($this->getColumnFilterStatement($i) as $column) {
                                 $query->when(is_array($column), function ($query) use ($search, $column) {
                                     foreach ($column as $col) {
-                                        $query->orWhereRaw('LOWER(' . $this->tablePrefix . $col . ') like ?', '%' . mb_strtolower($search) . '%');
+                                        $query->orWhereRaw('LOWER(' . (Str::contains(mb_strtolower($column), 'concat') ? '' : $this->tablePrefix) .  $col . ') like ?', '%' . mb_strtolower($search) . '%');
                                     }
                                 }, function ($query) use ($search, $column) {
-                                    $query->orWhereRaw('LOWER(' . $this->tablePrefix . $column . ') like ?', '%' . mb_strtolower($search) . '%');
+                                    $query->orWhereRaw('LOWER(' . (Str::contains(mb_strtolower($column), 'concat') ? '' : $this->tablePrefix) .  $column . ') like ?', '%' . mb_strtolower($search) . '%');
                                 });
                             }
                         });


### PR DESCRIPTION
Fix to prevent addGlobalSearch method to prepend tablePrefix when column contains '_concat_'.
It was generating a syntax error in the query, i.e.:
SQLSTATE[42000]: Syntax error or access violation: 1305 FUNCTION **DBNAME**.**TABLEPREFIX**CONCAT_WS does not exist