### PR TITLE
fix bug in SQLite dialect Expression

### DIFF
--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -351,10 +351,10 @@ class LivewireDatatable extends Component
         if (DB::connection() instanceof \Illuminate\Database\SQLiteConnection) {
             // SQLite dialect.
             return $selects->count() > 1
-                ? new Expression("('" . static::SEPARATOR . "' || " .
+                ? new Expression("(" .
                 collect($selects)->map(function ($select) {
                     return 'COALESCE(' . $this->tablePrefix . $select . ', \'\')';
-                })->join(" || '". static::SEPARATOR . "' || ") . ')')
+                })->join(" || '" . static::SEPARATOR . "' || ") . ')')
                 : $selects->first();
         } else {
             // Default to MySql dialect.


### PR DESCRIPTION
returned SQL values had a prepended separator, which prevented variables extraction.